### PR TITLE
Add `successful?` to the response

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,19 @@ or
 KSequencing.client.find_image("5a40be59fb9d7f27354c5efa", { token: "[you_token]" })
 ```
 
+Client can check whether request is success by
+
+```ruby
+response = KSequencing.client.find_image("5a40be59fb9d7f27354c5efa")
+if response.successful?
+  # Do stuff
+else
+  log.error("Request was not success, somethings went wrong.")
+end
+```
+
 ###### Sample response
-<KSequencing::Response @success=true, @status=200, @message="success" @meta={"code"=>200, "message"=>"success"}, @data={}, />
+<KSequencing::Response @status=200, @message="success" @meta={"code"=>200, "message"=>"success"}, @data={}, />
 
 ```json
 {
@@ -83,7 +94,6 @@ KSequencing.client.find_image("5a40be59fb9d7f27354c5efa", { token: "[you_token]"
       "status": "processed"
     }
   },
-  "success": true,
   "status": 200,
   "message": "success",
   "meta": {
@@ -140,7 +150,6 @@ KSequencing.image_closed_question.create({
     "project_id": "project_id",
     "status": "unprocess" 
   },
-  "success": true,
   "status": 200,
   "message": "success",
   "meta": { 
@@ -215,7 +224,6 @@ KSequencing.image_closed_question.all({
       ...
     ]
   },
-  "success": true,
   "status": 200,
   "message": "success",
   "total": 3,

--- a/lib/k_sequencing/client_response.rb
+++ b/lib/k_sequencing/client_response.rb
@@ -1,6 +1,6 @@
 module KSequencing
   class Response
-    attr_reader :count, :message, :status
+    attr_reader :total, :message, :status
     attr_accessor :data, :meta
 
     def initialize(data, response_code = '', response_message = 'success', meta = nil, total = 0)

--- a/lib/k_sequencing/client_response.rb
+++ b/lib/k_sequencing/client_response.rb
@@ -3,13 +3,16 @@ module KSequencing
     attr_reader :count, :message, :status
     attr_accessor :data, :meta
 
-    def initialize(data, success, response_code = '', response_message = 'success', meta = nil, total = 0)
+    def initialize(data, response_code = '', response_message = 'success', meta = nil, total = 0)
       @data = data
-      @success = success
       @status = response_code
       @message = response_message
-      @total = total unless total.nil?
       @meta = meta
+      @total = total unless total.nil?
+    end
+
+    def successful?
+      [200, 201].include? status
     end
   end
 end

--- a/test/k_sequencing/client_response_test.rb
+++ b/test/k_sequencing/client_response_test.rb
@@ -3,9 +3,17 @@ require 'test_helper'
 module KSequencing
   class ResponseTest < Minitest::Test
     def test_new_success_response
-      response = Response.new('response', true, 200, 'success', 'meta', 5)
+      response = Response.new('response', 200, 'success', 'meta', 5)
       refute_nil(response)
       refute_nil(response.data)
+      assert_equal(true, response.successful?)
+    end
+
+    def test_failure_response
+      response = Response.new('response', 500, 'failure', 'meta')
+      refute_nil(response)
+      refute_nil(response.data)
+      assert_equal(false, response.successful?)
     end
   end
 end

--- a/test/k_sequencing/client_response_test.rb
+++ b/test/k_sequencing/client_response_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module KSequencing
@@ -7,6 +9,10 @@ module KSequencing
       refute_nil(response)
       refute_nil(response.data)
       assert_equal(true, response.successful?)
+      assert_equal('response', response.data)
+      assert_equal('success', response.message)
+      assert_equal('meta', response.meta)
+      assert_equal(5, response.total)
     end
 
     def test_failure_response
@@ -14,6 +20,10 @@ module KSequencing
       refute_nil(response)
       refute_nil(response.data)
       assert_equal(false, response.successful?)
+      assert_equal('response', response.data)
+      assert_equal('failure', response.message)
+      assert_equal('meta', response.meta)
+      assert_equal(0, response.total)
     end
   end
 end


### PR DESCRIPTION
Jira issue: https://jira.datawow.io/browse/KIYO-341

# Overview
Client can be able to check whether request is success by using `response.successful?` with `Response` object

# Changes
- Adds `successful?` as a public method to the `client_response.rb`.
- Refactors some.
- Updates test case.

# Implementation Details
`successful?` will check whether response status is either `200` or `201`. Other cases, will treat as a failure response.

# Impact
Response result will no longer has `success` which is boolean value. Client's better to check by `response.successful?` instead.